### PR TITLE
[sage-notebook] Use twistd script for correct python version.

### DIFF
--- a/sci-mathematics/sage-notebook/files/sage-notebook-0.8-twistd-python-version.patch
+++ b/sci-mathematics/sage-notebook/files/sage-notebook-0.8-twistd-python-version.patch
@@ -1,0 +1,27 @@
+The Gentoo /usr/bin/twistd wrapper script will determine the python version
+using eselect, not taking the override from EPYTHON into account.  With this
+patch, a version matching the currently running python interpreter will be
+tried if it exists.
+
+2010-01-27 Martin von Gagern
+
+Index: sagenb-0.8.10/src/sagenb/sagenb/notebook/run_notebook.py
+===================================================================
+--- sagenb-0.8.10.orig/src/sagenb/sagenb/notebook/run_notebook.py
++++ sagenb-0.8.10/src/sagenb/sagenb/notebook/run_notebook.py
+@@ -360,7 +360,14 @@ reactor.addSystemEventTrigger('before',
+         if pidfile is None:
+             pidfile = os.path.join(directory, 'twistd.pid')
+ 
+-        cmd = 'twistd --pidfile="%s" -ny "%s"' % (pidfile, os.path.join(directory, 'twistedconf.tac'))
++        # Gentoo twistd executable detection: run a matching version of twistd
++        # if it exists, falling back to plain twistd.
++        exe = 'twistd'
++        for try_exe in [ ('/usr/bin/twistd-%d.%d' % tuple(sys.version_info[0:2])) ]:
++            if os.path.exists(try_exe):
++                exe = try_exe
++                break
++        cmd = '%s --pidfile="%s" -ny "%s"' % (exe, pidfile, os.path.join(directory, 'twistedconf.tac'))
+ 
+         # Check if a Twistd PID exists in the given directory
+         if platformType != 'win32':

--- a/sci-mathematics/sage-notebook/sage-notebook-0.8.11-r1.ebuild
+++ b/sci-mathematics/sage-notebook/sage-notebook-0.8.11-r1.ebuild
@@ -68,5 +68,8 @@ src_prepare() {
 	# Ticket: #10131
 	epatch "${FILESDIR}"/${PN}-0.8.2-add-pidfile-option.patch
 
+	# https://github.com/cschwan/sage-on-gentoo/pull/48
+	epatch "${FILESDIR}"/${PN}-0.8-twistd-python-version.patch
+
 	distutils_src_prepare
 }


### PR DESCRIPTION
Manually rebased [pull request 48](https://github.com/cschwan/sage-on-gentoo/pull/48).

Sage notebook used to create a backtrace for me, as twistd was run for python 2.7 but sage itself only installed for python 2.6. With this patch in place, the twistd script to launch is derived from the python version executing sage. I only applied the changes to 0.8.11 here, as that's the one I've installed. Feel free to add the patch to other versions as well, as you see fit.
