### PR TITLE
R requires the "minizip" useflag on newer zlib

### DIFF
--- a/package.use/sage-unstable
+++ b/package.use/sage-unstable
@@ -1,0 +1,4 @@
+# Use in addition to ./sage when running Gentoo unstable
+
+app-text/ghostscript-gpl    cups
+sys-libs/zlib               minizip


### PR DESCRIPTION
I get the following message when I try to emerge sage:

```
The following USE changes are necessary to proceed:
#required by dev-lang/R-2.14.0, required by dev-python/rpy-2.2.4, required by sci-mathematics/sage-4.7.2, required by sci-mathematics/sage-notebook-0.8.23-r1
>=sys-libs/zlib-1.2.5.1-r2 minizip
#required by net-print/cups-1.4.8-r22, required by dev-java/icedtea-bin-7.2.0-r2[X], required by virtual/jdk-1.7.0, required by dev-java/sun-jaf-1.1.1, required by dev-java/bcmail-1.45, required by dev-java/itext-2.1.5, required by sci-chemistry/jmol-12.0.45, required by sci-mathematics/sage-notebook-0.8.23-r1[java], required by sci-mathematics/sage-4.7.2, required by sage (argument)
>=app-text/ghostscript-gpl-9.04-r5 cups
```

The latter message is puzzling but seems to be unrelated to sage-on-gentoo, but the former seemed worth getting rid of "upstream", hence this commit. I'm completely new to Gentoo so please forgive me (and close this pull request) if this change is not the right thing to do.
