### PR TITLE
Strip all spaces from pkg-config output. Fixes issue #190.

### DIFF
--- a/sci-mathematics/sage/sage-5.6.ebuild
+++ b/sci-mathematics/sage/sage-5.6.ebuild
@@ -135,7 +135,7 @@ src_prepare() {
 		-e 's/^-l//' \
 		-e "s/ -l/\',\'/g" \
 		-e 's/.,.pthread//g' \
-		-e "s:  ::")\'
+		-e "s: ::g")\'
 
 	# patch to module_list.py because of trac 4539
 	epatch "${FILESDIR}"/${PN}-5.4-plural.patch


### PR DESCRIPTION
Not sure what went wrong in #191, but this one here should be better.
