### PR TITLE
fflas-ffpack fails to build with automake-1.13

### DIFF
--- a/sci-libs/fflas-ffpack/fflas-ffpack-1.6.0-r3.ebuild
+++ b/sci-libs/fflas-ffpack/fflas-ffpack-1.6.0-r3.ebuild
@@ -27,6 +27,7 @@ AUTOTOOLS_AUTORECONF="1"
 AUTOTOOLS_IN_SOURCE_BUILD="1"
 PATCHES=(
 	"${FILESDIR}/${P}-blaslapack-3.patch"
+	"${FILESDIR}/${P}-automake-1.13.patch"
 	)
 
 src_configure() {

--- a/sci-libs/fflas-ffpack/files/fflas-ffpack-1.6.0-automake-1.13.patch
+++ b/sci-libs/fflas-ffpack/files/fflas-ffpack-1.6.0-automake-1.13.patch
@@ -1,0 +1,11 @@
+--- configure.ac.orig	2013-04-26 19:18:02.027398807 +0200
++++ configure.ac	2013-04-26 19:17:52.875461193 +0200
+@@ -30,7 +30,7 @@
+ AC_CONFIG_MACRO_DIR([macros])
+ AC_CONFIG_AUX_DIR([build-aux])
+ AM_INIT_AUTOMAKE([1.8 gnu no-dependencies -Wall -Wno-portability])
+-AM_CONFIG_HEADER([config.h])
++AC_CONFIG_HEADERS([config.h])
+ AX_PREFIX_CONFIG_H(fflas-ffpack/fflas-ffpack-config.h, __FFLASFFPACK)
+ AC_PATH_PROG(RM, rm, $FALSE)
+ RM="$RM -f"


### PR DESCRIPTION
This fixes the usage of a depracated macro.
