### PR TITLE
iml fails to build with automake-1.13

### DIFF
--- a/sci-libs/iml/files/iml-1.0.3-automake-1.13.patch
+++ b/sci-libs/iml/files/iml-1.0.3-automake-1.13.patch
@@ -1,0 +1,10 @@
+--- configure.ac	2013-04-26 20:55:59.589534824 +0200
++++ configure.ac	2013-04-26 20:56:11.126465976 +0200
+@@ -3,7 +3,7 @@
+ AC_PREREQ(2.59)
+ AC_INIT(IML, 1.0.3)
+ AC_CONFIG_AUX_DIR(config)
+-AM_CONFIG_HEADER(config.h:config-h.in)
++AC_CONFIG_HEADERS(config.h:config-h.in)
+ AC_CONFIG_SRCDIR([src/RNSop.c])
+ AM_INIT_AUTOMAKE

--- a/sci-libs/iml/iml-1.0.3-r2.ebuild
+++ b/sci-libs/iml/iml-1.0.3-r2.ebuild
@@ -27,6 +27,7 @@ PATCHES=(
 	"${FILESDIR}"/${P}-use-any-cblas-implementation.patch
 	"${FILESDIR}"/${P}-fix-undefined-symbol.patch
 	"${FILESDIR}"/${P}-repl_removal.patch
+	"${FILESDIR}"/${P}-automake-1.13.patch
 )
 
 src_configure() {


### PR DESCRIPTION
This adds the same fix as for fflas-ffpack.
