### PR TITLE
Depend on dev-python/pyparsing since virtual/pyparsing is deprecated

### DIFF
--- a/dev-python/ipython/ipython-0.13.1-r1.ebuild
+++ b/dev-python/ipython/ipython-0.13.1-r1.ebuild
@@ -23,7 +23,7 @@ PY2_USEDEP=$(python_gen_usedep python2*)
 
 CDEPEND="dev-python/decorator[${PYTHON_USEDEP}]
 	dev-python/pexpect[${PY2_USEDEP}]
-	virtual/pyparsing[${PYTHON_USEDEP}]
+	dev-python/pyparsing[${PYTHON_USEDEP}]
 	dev-python/simplegeneric[${PYTHON_USEDEP}]
 	virtual/python-argparse[${PYTHON_USEDEP}]
 	emacs? ( app-emacs/python-mode virtual/emacs )

--- a/dev-python/ipython/ipython-0.13.1.ebuild
+++ b/dev-python/ipython/ipython-0.13.1.ebuild
@@ -25,7 +25,7 @@ IUSE="doc emacs examples matplotlib mongodb notebook octave
 
 CDEPEND="dev-python/decorator
 	dev-python/pexpect
-	virtual/pyparsing
+	dev-python/pyparsing
 	dev-python/simplegeneric
 	virtual/python-argparse
 	emacs? ( app-emacs/python-mode virtual/emacs )


### PR DESCRIPTION
This makes portage freak out, so it would be nice to get this in fast. I was unsure whether this requires a rev-bump.
