### PR TITLE
change LD in src_install with qt4 useflag, to fix a bug akin to #230 on s-o-g

### DIFF
--- a/sci-mathematics/pari/ChangeLog
+++ b/sci-mathematics/pari/ChangeLog
@@ -2,6 +2,10 @@
 # Copyright 1999-2013 Gentoo Foundation; Distributed under the GPL v2
 # $Header: /var/cvsroot/gentoo-x86/sci-mathematics/pari/ChangeLog,v 1.87 2012/03/06 17:06:06 bicatali Exp $
 
+  14 Sep 2013; <xhub@gentoo.org> pari-2.5.4-r1.ebuild:
+  change LD in src_install with qt4 useflag, to fix a bug akin to #230 on
+  s-o-g
+
   05 Jun 2013; François Bissey <francois.bissey@canterbury.ac.nz>
   pari-2.5.4-r1.ebuild:
   Set CPLUSPLUS to tc-getCXX and more elegant fix for issue #230

--- a/sci-mathematics/pari/pari-2.5.4-r1.ebuild
+++ b/sci-mathematics/pari/pari-2.5.4-r1.ebuild
@@ -128,7 +128,16 @@ src_test() {
 }
 
 src_install() {
-	default
+	if use qt4; then
+		emake DESTDIR="${D}" LD=$(tc-getCXX) install
+	else
+		emake DESTDIR="${D}" install
+	fi
+	local d
+	for d in README* ChangeLog AUTHORS NEWS TODO CHANGES THANKS BUGS \
+			FAQ CREDITS CHANGELOG ; do
+		[[ -s "${d}" ]] && dodoc "${d}"
+	done
 	dodoc MACHINES COMPAT
 	if use doc; then
 		# install gphelp and the pdf documentations manually.


### PR DESCRIPTION
I tried to update pari to 2.5.4-r1 and I've come across this error:

mkdir -p "/var/tmp/portage/sci-mathematics/pari-2.5.4-r1/image//usr/bin"
rm -f "/var/tmp/portage/sci-mathematics/pari-2.5.4-r1/image//usr/bin"/gp-2.5 "/var/tmp/portage/sci-mathematics/pari-2.5.4-r1/image//usr/bin"/gp
../config/install -m 644 ../examples/contfrac.gp "/var/tmp/portage/sci-mathematics/pari-2.5.4-r1/image//usr/share/pari"/examples
x86_64-pc-linux-gnu-gcc  -o "/var/tmp/portage/sci-mathematics/pari-2.5.4-r1/image//usr/bin"/gp-2.5 -L"/var/tmp/portage/sci-mathematics/pari-2.5.4-r1/image//usr/lib64" -O3 -Wall -fno-strict-aliasing -fomit-frame-pointer  -march=native -O2 -pipe  -Wl,--export-dynamic -Wl,--hash-style=gnu -Wl,-O1 -Wl,--as-needed -Wl,--hash-style=gnu -Wl,--sort-common gp.o gp_init.o gp_rl.o highlvl.o whatnow.o plotport.o plotQt4.o -Wl,-rpath,"/usr/lib64":/usr/lib64:/usr/lib -lpari -L/usr/lib -lreadline -L/usr/lib64/qt4 -lQtGui -lQtCore   -lm -ldl
../config/install -m 644 ../examples/lucas.gp    "/var/tmp/portage/sci-mathematics/pari-2.5.4-r1/image//usr/share/pari"/examples
../config/install -m 644 ../examples/extgcd.c    "/var/tmp/portage/sci-mathematics/pari-2.5.4-r1/image//usr/share/pari"/examples
../config/install -m 644 ../examples/rho.gp      "/var/tmp/portage/sci-mathematics/pari-2.5.4-r1/image//usr/share/pari"/examples
../config/install -m 644 ../examples/squfof.gp   "/var/tmp/portage/sci-mathematics/pari-2.5.4-r1/image//usr/share/pari"/examples
../config/install -m 644 ../examples/taylor.gp   "/var/tmp/portage/sci-mathematics/pari-2.5.4-r1/image//usr/share/pari"/examples
/usr/lib/gcc/x86_64-pc-linux-gnu/4.7.2/../../../../x86_64-pc-linux-gnu/bin/ld: plotQt4.o: undefined reference to symbol  «__cxa_rethrow@@CXXABI_1.3»
/usr/lib/gcc/x86_64-pc-linux-gnu/4.7.2/../../../../x86_64-pc-linux-gnu/bin/ld: note: «__cxa_rethrow@@CXXABI_1.3» is defined in DSO /usr/lib/gcc/x86_64-pc-linux-gnu/4.7.2/libstdc++.so.6 so try adding it to the linker command line
/usr/lib/gcc/x86_64-pc-linux-gnu/4.7.2/libstdc++.so.6: could not read symbols: Invalid operation
collect2: error: ld returned 1 exit status
make[1]: **\* [install-bin-dyn] Error 1

This is like the error found in issue #230, but this time in the install phase. There is a call to $(LD) in the target "install-bin-dyn" and LD is set to gcc. I fixed it by exporting LD=g++ in the src_install phase.
