### PR TITLE
Change SRC_URI to use the sageupstream mirror

### DIFF
--- a/sci-mathematics/sage-data-combinatorial_designs/sage-data-combinatorial_designs-20140630.ebuild
+++ b/sci-mathematics/sage-data-combinatorial_designs/sage-data-combinatorial_designs-20140630.ebuild
@@ -11,7 +11,7 @@ MY_P="${MY_PN}-$(replace_version_separator 1 '.')"
 
 DESCRIPTION="Data for Combinatorial Designs"
 HOMEPAGE="http://www.sagemath.org"
-SRC_URI="http://www.sagemath.org/packages/upstream/${MY_PN}/${MY_P}.tar.bz2"
+SRC_URI="mirror://sageupstream/${MY_PN}/${MY_P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"

--- a/sci-mathematics/sage-data-conway_polynomials/sage-data-conway_polynomials-0.4-r3.ebuild
+++ b/sci-mathematics/sage-data-conway_polynomials/sage-data-conway_polynomials-0.4-r3.ebuild
@@ -12,7 +12,7 @@ MY_P="conway_polynomials-${PV}"
 
 DESCRIPTION="Sage's conway polynomial database"
 HOMEPAGE="http://www.sagemath.org"
-SRC_URI="http://www.sagemath.org/packages/upstream/conway_polynomials/${MY_P}.tar.bz2"
+SRC_URI="mirror://sageupstream/conway_polynomials/${MY_P}.tar.bz2"
 
 LICENSE="GPL-2"
 SLOT="0"


### PR DESCRIPTION
The original URL for at least the `conway_polynomials` wasn't available any more.