### PR TITLE
Force sympy to build documentation using Python 2

### DIFF
--- a/dev-python/sympy/sympy-0.7.6.1-r1.ebuild
+++ b/dev-python/sympy/sympy-0.7.6.1-r1.ebuild
@@ -5,6 +5,7 @@
 EAPI=5
 
 PYTHON_COMPAT=( python{2_7,3_3,3_4} )
+DISTUTILS_ALL_SUBPHASE_IMPLS=( 'python2*' )
 
 inherit distutils-r1 eutils virtualx
 


### PR DESCRIPTION
The file `ext/numpydoc.py` contains unicode literals, which won't work with Python 3.0 through 3.4. The `REQUIRED_USE` setting forces the presence of Python 2.7 if documentation should be built.  But there is nothing to actually use Python 2 for building the documentation.  Reading from the [`distutils-r1.eclass`](https://github.com/gentoo/gentoo/blob/master/eclass/distutils-r1.eclass), the [`DISTUTILS_ALL_SUBPHASE_IMPLS`](https://github.com/gentoo/gentoo/blob/d853297bef8a0f8b816863f7584b9a5d243bc188/eclass/distutils-r1.eclass#L187-L210) variable is the appropriate tool to specify such a requirement.

See also [Gentoo bug 573282](https://bugs.gentoo.org/show_bug.cgi?id=573282).