### PR TITLE
dev-python/sphinx: Backport fixes for compatibility with docutils 0.13

### DIFF
--- a/dev-python/sphinx/files/sphinx-1.4.1-docutils13.patch
+++ b/dev-python/sphinx/files/sphinx-1.4.1-docutils13.patch
@@ -1,0 +1,34 @@
+# git diff 3adc236114^..7dabcdee91 -- sphinx/writers/html.py
+# and parts of edfdd3ec78 as well in order to make these apply
+
+diff --git a/sphinx/writers/html.py b/sphinx/writers/html.py
+index 7b666aa5..d6bdd833 100644
+--- a/sphinx/writers/html.py
++++ b/sphinx/writers/html.py
+@@ -458,9 +458,9 @@ class HTMLTranslator(BaseTranslator):
+             node['uri'] = posixpath.join(self.builder.imgpath,
+                                          self.builder.images[olduri])
+ 
+-        if node['uri'].lower().endswith('svg') or \
+-           node['uri'].lower().endswith('svgz'):
+-            atts = {'src': node['uri']}
++        uri = node['uri']
++        if uri.lower().endswith(('svg', 'svgz')):
++            atts = {'src': uri}
+             if 'width' in node:
+                 atts['width'] = node['width']
+             if 'height' in node:
+@@ -492,6 +492,13 @@ class HTMLTranslator(BaseTranslator):
+                         node['height'] = str(size[1])
+         BaseTranslator.visit_image(self, node)
+ 
++    # overwritten
++    def depart_image(self, node):
++        if node['uri'].lower().endswith(('svg', 'svgz')):
++            self.body.append(self.context.pop())
++        else:
++            BaseTranslator.depart_image(self, node)
++
+     def visit_toctree(self, node):
+         # this only happens when formatting a toc from env.tocs -- in this
+         # case we don't want to include the subtree

--- a/dev-python/sphinx/sphinx-1.4.4-r1.ebuild
+++ b/dev-python/sphinx/sphinx-1.4.4-r1.ebuild
@@ -45,6 +45,7 @@ DEPEND="${RDEPEND}
 
 PATCHES=(
 	"${FILESDIR}"/${PN}-1.4.1-Makefile.patch
+	"${FILESDIR}"/${PN}-1.4.1-docutils13.patch
 	)
 
 S="${WORKDIR}/${MY_P}"


### PR DESCRIPTION
Fixes #451.

I decided not to restrict the version in the dependency, but instead to backport the required modifications. Doing so will avoid contributing to the already long list of packages version-pinned due to some Sage requirement. The first chunk of the patch is probably mostly cosmetic, and not strictly necessary. Let me know if you'd like me to remove that chunk.

See [file history of `html.py`](https://github.com/sphinx-doc/sphinx/commits/7dabcdee91f1d0d9420f4926ad12a95c3aa4422f/sphinx/writers/html.py) for the commits mentioned in the header of the patch.