### PR TITLE
added CeCILL-B license to MISC-FREE license group

### DIFF
--- a/profiles/license_groups
+++ b/profiles/license_groups
@@ -1,0 +1,1 @@
+MISC-FREE CeCILL-B


### PR DESCRIPTION
For completion as CeCILL-B license is not  in gentoo main tree
see also https://github.com/gentoo-science/sci/issues/771