### PR TITLE
sci-mathematics/sage: support Mathematica interface

### DIFF
--- a/sci-mathematics/sage/sage-7.5.1-r1.ebuild
+++ b/sci-mathematics/sage/sage-7.5.1-r1.ebuild
@@ -385,7 +385,8 @@ python_install_all() {
 	python_foreach_impl python_doscript sage-preparse sage-startuptime.py
 
 	dobin sage-native-execute sage \
-		sage-python sage-version.sh
+		sage-python sage-version.sh \
+		math-readline
 
 	# install sage-env under /etc
 	insinto /etc

--- a/sci-mathematics/sage/sage-7.6.ebuild
+++ b/sci-mathematics/sage/sage-7.6.ebuild
@@ -413,7 +413,8 @@ python_install_all() {
 	python_foreach_impl python_doscript sage-preparse sage-startuptime.py
 
 	dobin sage-native-execute sage \
-		sage-python sage-version.sh
+		sage-python sage-version.sh \
+		math-readline
 
 	# install sage-env under /etc
 	insinto /etc

--- a/sci-mathematics/sage/sage-9999.ebuild
+++ b/sci-mathematics/sage/sage-9999.ebuild
@@ -430,7 +430,8 @@ python_install() {
 	python_doscript \
 		sage-cython \
 		sage-notebook \
-		sage-run-cython
+		sage-run-cython \
+		math-readline
 
 	# additonal helper scripts
 	python_doscript sage-preparse sage-startuptime.py


### PR DESCRIPTION
The Mathematica interface needs the `math-readline` helper script.

With this patch everything works as described in http://doc.sagemath.org/html/en/reference/interfaces/sage/interfaces/mathematica.html