### PR TITLE
Fetch gfan sources from Sage mirror

### DIFF
--- a/sci-mathematics/gfan/gfan-0.6.2.ebuild
+++ b/sci-mathematics/gfan/gfan-0.6.2.ebuild
@@ -7,7 +7,7 @@ inherit flag-o-matic toolchain-funcs
 
 DESCRIPTION="computes Groebner fans and tropical varities"
 HOMEPAGE="http://home.math.au.dk/jensen/software/gfan/gfan.html"
-SRC_URI="http://home.math.au.dk/jensen/software/gfan/${PN}${PV}.tar.gz"
+SRC_URI="mirror://sageupstream/gfan/${PN}${PV}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"


### PR DESCRIPTION
The upstream URL appears to be unavailable at the moment.
See #504 for last incident of this kind.
Using the Sage mirror should be both faster and more reliable.