### PR TITLE
sci-mathematics/sage: donot depend on subslots.

### DIFF
--- a/sci-mathematics/sage/sage-8.8.ebuild
+++ b/sci-mathematics/sage/sage-8.8.ebuild
@@ -67,7 +67,7 @@ CDEPEND="dev-libs/gmp:0=
 	~sci-libs/pynac-0.7.24[-giac,${PYTHON_USEDEP}]
 	>=sci-libs/symmetrica-2.0-r3
 	>=sci-libs/zn_poly-0.9
-	>=sci-mathematics/gap-4.10.1:0/4.10.1[recommended_pkgs]
+	>=sci-mathematics/gap-4.10.1[recommended_pkgs]
 	>=sci-mathematics/giac-1.5.0.43
 	>=sci-mathematics/glpk-4.63:0=[gmp]
 	>=sci-mathematics/lcalc-1.23-r10[pari]


### PR DESCRIPTION
Subslots are not needed in dependencies and cause slot conflicts.

Package-Manager: Portage-2.3.69, Repoman-2.3.12
RepoMan-Options: --force
Signed-off-by: Benda Xu <heroxbd@gentoo.org>