### PR TITLE
sci-mathematics/ratpoints: Update source URI to HTTP only

### DIFF
--- a/sci-mathematics/ratpoints/ratpoints-2.1.3-r4.ebuild
+++ b/sci-mathematics/ratpoints/ratpoints-2.1.3-r4.ebuild
@@ -6,8 +6,8 @@ EAPI=6
 inherit flag-o-matic toolchain-funcs
 
 DESCRIPTION="Ratpoints tries to find all rational points on a hyperelliptic curve"
-HOMEPAGE="https://www.mathe2.uni-bayreuth.de/stoll/programs/index.html"
-SRC_URI="https://www.mathe2.uni-bayreuth.de/stoll/programs/${P}.tar.gz"
+HOMEPAGE="http://www.mathe2.uni-bayreuth.de/stoll/programs/index.html"
+SRC_URI="http://www.mathe2.uni-bayreuth.de/stoll/programs/${P}.tar.gz"
 
 LICENSE="GPL-2"
 SLOT="0"


### PR DESCRIPTION
The HTTPS version of the site is not responsive.

Package-Manager: Portage-2.3.89, Repoman-2.3.20
Signed-off-by: Stephen Shkardoon <ss23@ss23.geek.nz>