### PR TITLE
Fix sci-mathematics/maxima using LDFLAGS incorrectly

### DIFF
--- a/sci-mathematics/maxima/maxima-5.44.0.ebuild
+++ b/sci-mathematics/maxima/maxima-5.44.0.ebuild
@@ -3,7 +3,7 @@
 
 EAPI=6
 
-inherit autotools elisp-common eutils xdg-utils
+inherit autotools elisp-common eutils xdg-utils flag-o-matic
 
 DESCRIPTION="Free computer algebra environment based on Macsyma"
 HOMEPAGE="http://maxima.sourceforge.net/"
@@ -145,6 +145,7 @@ src_configure() {
 	fi
 
 	econf ${CONFS} \
+		LDFLAGS="$(raw-ldflags)" \
 		$(use_with tk wish) \
 		$(use_enable emacs) \
 		--with-lispdir="${EPREFIX}/${SITELISP}/${PN}"


### PR DESCRIPTION
In ebuilds, `LDFLAGS` contain the compiler flags, and usually gcc is invoked instead of ld directly.

However, some packages invoke ld with `LDFLAGS`, and thus break. The workaround is to filter LDFLAGS before passing it to the package.

[1] discusses the similar problem where LDFLAGS are being passed to ld directly, and how to fix it.

[2] describes how the non-linker flags should be filtered out by `$(raw-ldflags)` altogether.

In my case, I have

    CFLAGS="${CFLAGS} -flto=24 -fno-fat-lto-objects"
    CXXFLAGS="${CXXFLAGS} -flto=24 -fno-fat-lto-objects"
    LDFLAGS="${LDFLAGS} -flto=24 -fuse-linker-plugin"

Which leads to

    /usr/lib/gcc/x86_64-pc-linux-gnu/9.3.0/../../../../x86_64-pc-linux-gnu/bin/ld: unrecognized option '--as-needed -flto=24 -fuse-linker-plugin'
    /usr/lib/gcc/x86_64-pc-linux-gnu/9.3.0/../../../../x86_64-pc-linux-gnu/bin/ld: use the --help option for usage information
    collect2: error: ld returned 1 exit status

[1] https://wiki.gentoo.org/wiki/Project:Quality_Assurance/As-needed#Failure_in_compile.2C_unrecognized_option
[2] https://bugs.gentoo.org/441808