### PR TITLE
Remove package.use/sage-unstable reference in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -77,11 +77,6 @@ QUICK INSTALLATION GUIDE
      ln -s <path-to-layman>/sage-on-gentoo/package.use/sage \
            /etc/portage/package.use/sage
 
-   If you are using unstable or Funtoo you may also need the following file::
-
-     ln -s <path-to-layman>/sage-on-gentoo/package.use/sage-unstable \
-           /etc/portage/package.use/sage-unstable
-
    <path-to-layman> is usually /var/lib/layman (this path used to be
    /usr/local/portage/layman for older version of layman).
 


### PR DESCRIPTION
This commit removes the suggestion of symlinking package.use/sage-unstable for unstable or Funtoo users. It looks like package.use/sage-unstable was removed in commit b8776de6ae44de8c6c95488d8fe788a37e5ba4e4.