### PR TITLE
fix dev-gap dependencies for sage-9.3

### DIFF
--- a/package.keywords/sage-9.3
+++ b/package.keywords/sage-9.3
@@ -90,7 +90,7 @@ sci-mathematics/sage_numerical_backends_coin
 ~dev-gap/GAPDoc-1.6.3
 ~dev-gap/primgrp-3.4.0
 ~dev-gap/SmallGrp-1.4.1
->=dev-gap/transgrp-2.0.5
+~dev-gap/transgrp-3.0
 # default autoloaded packages
 # Beware atlasrep is potentially broken
 # as it may try to write in system locations.
@@ -110,7 +110,7 @@ sci-mathematics/sage_numerical_backends_coin
 >=dev-gap/fga-1.4.0
 ~dev-gap/ctbllib-1.2_p2
 >=dev-gap/autpgrp-1.10.2
->=dev-gap/irredsol-1.4.1
+~dev-gap/irredsol-1.4.1
 # other packages
 >=dev-gap/HAPcryst-0.1.13
 >=dev-gap/MapClass-1.4.4
@@ -127,7 +127,7 @@ sci-mathematics/sage_numerical_backends_coin
 >=dev-gap/guava-3.15
 >=dev-gap/hap-1.26
 >=dev-gap/hecke-1.5.3
->=dev-gap/io-4.7.0
+~dev-gap/io-4.7.0
 >=dev-gap/liealgdb-2.2.1
 >=dev-gap/liepring-1.9.2-r2
 >=dev-gap/liering-2.4.1


### PR DESCRIPTION
Newer version of these packages depend on GAP 4.11.1 which is not
enabled yet.