### PR TITLE
change symlink for threejs

### DIFF
--- a/media-gfx/threejs-sage-extension/threejs-sage-extension-122-r1.ebuild
+++ b/media-gfx/threejs-sage-extension/threejs-sage-extension-122-r1.ebuild
@@ -29,5 +29,5 @@ src_install(){
 	# fro sage 9.4 onwards we need a versionned folder
 	# to preserve compatibility with 9.3 in this release, 
 	# we provide it as a symlink
-	dosym ../ /usr/share/sage/threejs/r${PV}
+	dosym build /usr/share/sage/threejs/r${PV}
 }


### PR DESCRIPTION
According to https://trac.sagemath.org/ticket/30972 `r122` should be symlink to `build`:

```patch
--- a/src/sage/repl/rich_output/backend_ipython.py
+++ b/src/sage/repl/rich_output/backend_ipython.py
@@ -413,8 +413,9 @@ class BackendIPythonCommandline(BackendIPython):
             '...<script ...</script>...'
         """
         from sage.env import THREEJS_DIR
+        from sage.repl.rich_output.display_manager import _required_threejs_version
 
-        script = os.path.join(THREEJS_DIR, 'build/three.min.js')
+        script = os.path.join(THREEJS_DIR, '{}/three.min.js'.format(_required_threejs_version()))
```

When I did `list_plot3d(matrix(RDF, n, [(i+j)%n for i in [1..n] for j in [1..n]]))` I get 
```
<script src="/usr/share/sage/threejs/r122/three.min.js"></script>
```
in generated html file

Well, that file exists only when
```
$ tree /usr/share/sage/threejs
/usr/share/sage/threejs
├── build
│   └── three.min.js
├── r122 -> build
└── version
```