### PR TITLE
dev-python/pplpy-0.8.7: fix invalid BDEPEND

### DIFF
--- a/dev-python/pplpy/pplpy-0.8.7-r1.ebuild
+++ b/dev-python/pplpy/pplpy-0.8.7-r1.ebuild
@@ -20,8 +20,7 @@ DEPEND=">=dev-python/gmpy-2.1.0[${PYTHON_USEDEP}]
 	>=dev-libs/ppl-1.2
 	doc? ( dev-python/sphinx[${PYTHON_USEDEP}] )"
 RDEPEND="${DEPEND}"
-BDEPEND="dev-python/cython[${PYTHON_USEDEP}]
-	dev-python/cython-3.0.0"
+BDEPEND="<dev-python/cython-3[${PYTHON_USEDEP}]"
 
 python_compile() {
 	# automatic parallel building with python3.5+ is not safe


### PR DESCRIPTION
Fix error message introduced by this [commit](https://github.com/cschwan/sage-on-gentoo/commit/f53019daa8bb643a2e73be29e278e8ad0e7d83b1)
```
!!! The following installed packages are masked:
- dev-python/pplpy-0.8.7::sage-on-gentoo (masked by: invalid: BDEPEND: Invalid atom (dev-python/cython-3.0.0), token 2 in '/var/db/pkg/dev-python/pplpy-0.8.7/BDEPEND')
For more information, see the MASKED PACKAGES section in the emerge
man page or refer to the Gentoo Handbook.
``` 