### PR TITLE
sci-mathematics/palp: miscellaneous updates

### DIFF
--- a/sci-mathematics/palp/palp-2.20-r1.ebuild
+++ b/sci-mathematics/palp/palp-2.20-r1.ebuild
@@ -1,23 +1,31 @@
 # Copyright 1999-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=6
+EAPI=8
 
 inherit toolchain-funcs flag-o-matic multibuild
 
-DESCRIPTION="A Package for Analyzing Lattice Polytopes"
+DESCRIPTION="Package for Analyzing Lattice Polytopes (PALP)"
 HOMEPAGE="http://hep.itp.tuwien.ac.at/~kreuzer/CY/CYpalp.html"
 SRC_URI="http://hep.itp.tuwien.ac.at/~kreuzer/CY/palp/${P}.tar.gz"
-#SRC_URI="mirror://sagemath/${P}.tar.gz"
 
-LICENSE="GPL-2"
+LICENSE="GPL-3"
 SLOT="0"
 KEYWORDS="~amd64 ~x86 ~amd64-linux ~x86-linux ~ppc-macos ~x64-macos"
 IUSE=""
 
-DEPEND=""
-RDEPEND="${DEPEND}"
+# The mori.x program writes code to a temporary file and then passes it
+# to /usr/bin/Singular to interpret. It also uses cat, grep, awk, and rm
+# in shell commands but those are presumed to be available on Gentoo.
+RDEPEND="sci-mathematics/singular"
 
+# SageMath has for ever shipped a custom installation of palp that
+# builds everything four times: once optimized for dimensions d <= 4,
+# once for d <= 5, once for d <= 6, and once for d <= 11 . The resulting
+# binaries are given a suffix corresponding to the dimension that they
+# were optimized for. For example, the upstream poly.x executable
+# optimized for d <= 4 is (and must be for SageMath to utilize it) named
+# poly-4d.x.
 MULTIBUILD_VARIANTS=( 4 5 6 11 )
 
 # this flag break the executable with certain versions of gcc
@@ -34,7 +42,8 @@ src_prepare(){
 }
 
 palp_compile(){
-	CPPFLAGS=-DPOLY_Dmax="${MULTIBUILD_VARIANT}" emake
+	DIMCPPFLAGS="-DPOLY_Dmax=${MULTIBUILD_VARIANT}"
+	CPPFLAGS="${CPPFLAGS} ${DIMCPPFLAGS}" emake
 }
 
 src_compile(){


### PR DESCRIPTION
I took a look at this again to see how much work it would be to get it into ::gentoo, and the answer is still "a lot." It's got a `tmpnam()` vulnerability in a context that allows code execution, and a new problem in that it fails to compile with clang now.

I wrote Harald Skarke an email this morning pointing out a few of the issues and asking about project hosting on Gitlab or Github -- somewhere we could pool our resources.

In any case, I found a few ebuild improvements during my failed attempt.
